### PR TITLE
Upgrades to Event & Context Handling

### DIFF
--- a/lib/MaterializeModal.coffee
+++ b/lib/MaterializeModal.coffee
@@ -51,7 +51,13 @@ class @MaterializeModalClass
     #
     @injectContainer()
     #
-    # (2) Update the this.options ReactiveVar, which will
+    # (2) If there is a bodyTemplate,
+    #
+    if options.bodyTemplate?
+      Template.materializeModal.inheritsEventsFrom options.bodyTemplate
+      delete Template[options.bodyTemplate].__eventMaps
+    #
+    # (3) Update the this.options ReactiveVar, which will
     #     cause the dynamic Template inside materializeModalContainer
     #     to re-render.
     #
@@ -224,7 +230,7 @@ class @MaterializeModalClass
     result = {}
     for key in form?.serializeArray()
       @addValueToObjFromDotString(result, key.name, key.value)
-    
+
     # Override the result with the boolean values of checkboxes, if any
     for check in form?.find "input:checkbox"
       if $(check).prop('name')
@@ -262,11 +268,11 @@ class @MaterializeModalClass
   doSubmitCallback: (context) ->
     options = @templateOptions.get()
     return true unless options.callback?
-    
+
     try
       response =
         submit: true
-      
+
       switch options.type
         when 'prompt'
           response.value = $(options.inputSelector).val()
@@ -281,7 +287,7 @@ class @MaterializeModalClass
         console.error("MaterializeModal Callback returned Error", error)
         Materialize.toast(error.reason, 3000, 'toast-error')
         return false
-    
+
     catch error
       options.callback(error, null)
     true

--- a/lib/MaterializeModal.coffee
+++ b/lib/MaterializeModal.coffee
@@ -51,7 +51,9 @@ class @MaterializeModalClass
     #
     @injectContainer()
     #
-    # (2) If there is a bodyTemplate,
+    # (2) If there is a bodyTemplate, we want its events to be handled
+    #     by Template.materializeModal -- this way, we can expose events
+    #     originating from footerTemplate directly into bodyTemplate events!
     #
     if options.bodyTemplate?
       Template.materializeModal.inheritsEventsFrom options.bodyTemplate

--- a/lib/MaterializeModal.coffee
+++ b/lib/MaterializeModal.coffee
@@ -51,15 +51,7 @@ class @MaterializeModalClass
     #
     @injectContainer()
     #
-    # (2) If there is a bodyTemplate, we want its events to be handled
-    #     by Template.materializeModal -- this way, we can expose events
-    #     originating from footerTemplate directly into bodyTemplate events!
-    #
-    if options.bodyTemplate?
-      Template.materializeModal.inheritsEventsFrom options.bodyTemplate
-      delete Template[options.bodyTemplate].__eventMaps
-    #
-    # (3) Update the this.options ReactiveVar, which will
+    # (2) Update the this.options ReactiveVar, which will
     #     cause the dynamic Template inside materializeModalContainer
     #     to re-render.
     #

--- a/lib/modal.coffee
+++ b/lib/modal.coffee
@@ -99,9 +99,13 @@ Template.materializeModal.helpers
   modalFooter: ->
     @footerTemplate or 'materializeModalFooter'
 
+#
+# Extend data context helpers (title, footer, etc.) into the modal
+# body wrapper.
+#
+Template.materializeModalBody.inheritsHelpersFrom "materializeModal"
 
 Template.materializeModal.events
-
   "click #closeButton": (e, tmpl) ->
     e.preventDefault()
     console.log('closeButton') if DEBUG
@@ -123,8 +127,3 @@ Template.materializeModalForm.helpers
   #
   isForm: ->
     @type in [ 'form', 'prompt' ]
-
-
-Template.materializeModalStatus.helpers
-  progressMessage: ->
-    #....

--- a/lib/modal.coffee
+++ b/lib/modal.coffee
@@ -71,14 +71,14 @@ Template.materializeModal.onDestroyed ->
 
 
 Template.materializeModal.helpers
-  
+
   #
   # bodyTemplate: The name of the template that should be rendered
   #               in the modal's body area.
   #
   bodyTemplate: ->
     @bodyTemplate or null
-  
+
   #
   # icon: Return a Material icon code for the Modal.
   #
@@ -92,22 +92,16 @@ Template.materializeModal.helpers
           'warning'
         when 'error'
           'error'
-  
+
   #
   # modalFooter:
   #
   modalFooter: ->
     @footerTemplate or 'materializeModalFooter'
-  
-  #
-  # modalFooterData:
-  #
-  modalFooterData: ->
-    _.extend({}, @, @footerTemplateData)
 
 
 Template.materializeModal.events
-  
+
   "click #closeButton": (e, tmpl) ->
     e.preventDefault()
     console.log('closeButton') if DEBUG

--- a/lib/modal.html
+++ b/lib/modal.html
@@ -7,6 +7,26 @@
   {{/if}}
 </template>
 
+<template name="materializeModalBody">
+  <div class="modal-content">
+    <!-- Add a title, if one was defined -->
+    {{#if title}}
+      <h4 class="modal-title" id="materializeModalLabel">
+        {{#if icon}}<i class="material-icons">{{icon}}</i>{{/if}}
+        {{{title}}}
+      </h4>
+    {{/if}}
+
+    <!--  Modal body -->
+    <div class="modal-body">
+      {{> Template.contentBlock }}
+    </div>
+  </div>
+
+  <!--  Add in footer, if one was defined -->
+  {{> Template.dynamic template=modalFooter data=this}}
+</template>
+
 <template name="materializeModal">
   <div id="materializeModal" class="materialize-modal modal
     {{#if fixedFooter}}modal-fixed-footer{{/if}}
@@ -14,29 +34,15 @@
     {{#if fullscreen}}full-screen{{/if}} {{class}}">
 
     {{#materializeModalForm}}
-      <div class="modal-content">
-        <!-- Add a title, if one was defined -->
-        {{#if title}}
-          <h4 class="modal-title" id="materializeModalLabel">
-            {{#if icon}}<i class="material-icons">{{icon}}</i>{{/if}}
-            {{{title}}}
-          </h4>
-        {{/if}}
-
-        <!--  Modal body -->
-        <div class="modal-body">
-          {{#if bodyTemplate}}
-            <!--  If a bodyTemplate was specified, insert it here. -->
-            {{> Template.dynamic template=bodyTemplate data=this}}
-          {{else}}
-            <!-- If no bodyTemplate, render message instead. -->
-            {{{message}}}
-          {{/if}}
-        </div>
-      </div>
-
-      <!--  Add in footer, if one was defined -->
-      {{> Template.dynamic template=modalFooter data=this}}
+      {{#if bodyTemplate}}
+        <!--  If a bodyTemplate was specified, insert it here. -->
+        {{> Template.dynamic template=bodyTemplate data=this}}
+      {{else}}
+        <!-- If no bodyTemplate, render message instead. -->
+        {{#materializeModalBody}}
+          {{{message}}}
+        {{/materializeModalBody}}
+      {{/if}}
     {{/materializeModalForm}}
   </div>
 </template>
@@ -56,29 +62,35 @@
 <!-- Templates to insert into the mainBody above -->
 
 <template name="materializeModalAlert">
-  <div class="alert alert-warning">
-    <strong id='label'>{{label}}</strong> <span id='message'>{{{message}}}</span>
-  </div>
+  {{#materializeModalBody}}
+    <div class="alert alert-warning">
+      <strong id='label'>{{label}}</strong> <span id='message'>{{{message}}}</span>
+    </div>
+  {{/materializeModalBody}}
 </template>
 
 <template name="materializeModalError">
-  <div class="alert alert-danger">
-    <h4 id='label'>{{label}}</h4>
-    <strong id ='message'>{{message}}</strong>
-  </div>
+  {{#materializeModalBody}}
+    <div class="alert alert-danger">
+      <h4 id='label'>{{label}}</h4>
+      <strong id ='message'>{{message}}</strong>
+    </div>
+  {{/materializeModalBody}}
 </template>
 
 <template name="materializeModalPrompt">
-  <div class="prompt">
-    <div class="col s12">
-      <div class="row">
-        <div class="input-field col s12">
-          <input id="prompt-input" class="validate" type="text" placeholder="{{placeholder}}" required autofocus />
-          <label for="prompt-input">{{message}}</label>
+  {{#materializeModalBody}}
+    <div class="prompt">
+      <div class="col s12">
+        <div class="row">
+          <div class="input-field col s12">
+            <input id="prompt-input" class="validate" type="text" placeholder="{{placeholder}}" required autofocus />
+            <label for="prompt-input">{{message}}</label>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  {{/materializeModalBody}}
 </template>
 
 <template name="materializeModalForm">
@@ -92,19 +104,23 @@
 </template>
 
 <template name="materializeModalProgress">
-  <div class="progress">
-    <div class="determinate" style="width: {{progress}};"></div>
-  </div>
-  <div id="progressMessage">
-    {{progress}} <span class="grey-text text-darken-1">{{message}}</span>
-  </div>
+  {{#materializeModalBody}}
+    <div class="progress">
+      <div class="determinate" style="width: {{progress}};"></div>
+    </div>
+    <div id="progressMessage">
+      {{progress}} <span class="grey-text text-darken-1">{{message}}</span>
+    </div>
+  {{/materializeModalBody}}
 </template>
 
 <template name="materializeModalStatus">
-  <div id="statusMessage">
-    <i class="fa fa-spinner fa-spin fa-2x"></i>
-    <span class="room-for-spin" id="progressMessage">{{progressMessage}}</span>
-  </div>
+  {{#materializeModalBody}}
+    <div id="statusMessage">
+      <i class="fa fa-spinner fa-spin fa-2x"></i>
+      <span class="room-for-spin" id="progressMessage">{{progressMessage}}</span>
+    </div>
+  {{/materializeModalBody}}
 </template>
 
 <template name="materializeModalSelect">
@@ -120,48 +136,50 @@
 </template>
 
 <template name="materializeModalLoading">
-  <div id="materialModalLoading" class='row center'>
-    <div id='loadingMessage'>{{message}}</div>
-    <div class="preloader-wrapper big active">
-      <div class="spinner-layer spinner-blue">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
+  {{#materializeModalBody}}
+    <div id="materialModalLoading" class='row center'>
+      <div id='loadingMessage'>{{message}}</div>
+      <div class="preloader-wrapper big active">
+        <div class="spinner-layer spinner-blue">
+          <div class="circle-clipper left">
+            <div class="circle"></div>
+          </div><div class="gap-patch">
+            <div class="circle"></div>
+          </div><div class="circle-clipper right">
+            <div class="circle"></div>
+          </div>
         </div>
-      </div>
 
-      <div class="spinner-layer spinner-red">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
+        <div class="spinner-layer spinner-red">
+          <div class="circle-clipper left">
+            <div class="circle"></div>
+          </div><div class="gap-patch">
+            <div class="circle"></div>
+          </div><div class="circle-clipper right">
+            <div class="circle"></div>
+          </div>
         </div>
-      </div>
 
-      <div class="spinner-layer spinner-yellow">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
+        <div class="spinner-layer spinner-yellow">
+          <div class="circle-clipper left">
+            <div class="circle"></div>
+          </div><div class="gap-patch">
+            <div class="circle"></div>
+          </div><div class="circle-clipper right">
+            <div class="circle"></div>
+          </div>
         </div>
-      </div>
 
-      <div class="spinner-layer spinner-green">
-        <div class="circle-clipper left">
-          <div class="circle"></div>
-        </div><div class="gap-patch">
-          <div class="circle"></div>
-        </div><div class="circle-clipper right">
-          <div class="circle"></div>
+        <div class="spinner-layer spinner-green">
+          <div class="circle-clipper left">
+            <div class="circle"></div>
+          </div><div class="gap-patch">
+            <div class="circle"></div>
+          </div><div class="circle-clipper right">
+            <div class="circle"></div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  {{/materializeModalBody}}
 </template>

--- a/lib/modal.html
+++ b/lib/modal.html
@@ -36,7 +36,7 @@
       </div>
 
       <!--  Add in footer, if one was defined -->
-      {{> Template.dynamic template=modalFooter data=modalFooterData}}
+      {{> Template.dynamic template=modalFooter data=this}}
     {{/materializeModalForm}}
   </div>
 </template>

--- a/package.js
+++ b/package.js
@@ -18,6 +18,7 @@ Package.onUse(function(api, where) {
 
   api.use([
     'softwarerero:accounts-t9n@1.1.4',
+    'aldeed:template-extension@3.4.3',
     'coffeescript'
   ], ["client"]);
 


### PR DESCRIPTION
For a concise demonstration of the improvements I have implemented here, please see the added example:  http://materializemodal.meteor.com/#custom-example

The idea is to let users define modal logic in the bodyTemplate's `events({})` like any other Meteor template, so they do not get stuck with callbacks.
## Problem Description

While implementing some basic use cases with this package, I came across two common problems.
1.  `footerTemplate` cannot access `bodyTemplate`'s data context.
2.  Very often a user might have events which depend on elements contained in `bodyTemplate`, but _triggered_ by buttons contained inside `footerTemplate` -- which are disjoint templates.

**In a nutshell, I wanted to make it super easy for a user to write `bodyTemplate` event maps that can depend on buttons from the footer.**
## Solutions
1.  I have removed the superfluous `footerTemplateData` field -- footers now inherit the same transparent data context that everything else in the modal does.  Whatever static or reactive data gets passed in is easily accessible by `{{varName}}` reference in both `bodyTemplate` and `footerTemplate`.
2.  I have added 2 lines of code that cause the `Template.materializeModal` template to inherit and handle the events from `bodyTemplate`.  Since `Template.materializeModal` contains both the `footerTemplate` and `bodyTemplate`, the user can write event maps for their `bodyTemplate` that will "automatically" handle all aspects of modal logic (if the user wants).  This is far more Meteoric than trying to pass data contexts through callbacks, et cetera.
