### PR TITLE
fix bug: closeModal being called twice

### DIFF
--- a/lib/MaterializeModal.coffee
+++ b/lib/MaterializeModal.coffee
@@ -71,7 +71,7 @@ class @MaterializeModalClass
   #                           - context is the data that might be relevant to
   #                             the submitCallback, such as the submitted form.
   #
-  close: (submit=false, context=null) ->
+  close: (submit=false, context=null, closeModal=true) ->
     console.log "MaterializeModal.close()" if DEBUG
     options = @templateOptions.get()
     if options? # if there are no options, there is no modal -- there is nothing to close!
@@ -87,10 +87,13 @@ class @MaterializeModalClass
       # If the callback had no errors, close the modal.
       #
       if cbSuccess
-        @$modal.closeModal
-          out_duration: options.outDuration
-          complete: =>
-            @templateOptions.set null
+        if closeModal
+          @$modal.closeModal
+            out_duration: options.outDuration
+            complete: =>
+              @templateOptions.set null
+        else
+          @templateOptions.set null
 
 
   #

--- a/lib/modal.coffee
+++ b/lib/modal.coffee
@@ -74,7 +74,7 @@ Template.materializeModal.onRendered ->
 
     complete: ->
       console.log("materializeModal: complete") if DEBUG
-      MaterializeModal.close(false)
+      MaterializeModal.close(false, null, false)
 
 
 Template.materializeModal.onDestroyed ->


### PR DESCRIPTION
after open a modal, close it, open again... the z-index will decrease, which cause a lot of problems.

by review the materialize and your code, I found you call `close` on modal complete callback, but `close` will close modal again... this lead to `closeModal` being called twice.

this pr try to fix it in the simplest way. but you can think it twice how to do it better.
